### PR TITLE
add values to mapper config section

### DIFF
--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/cspace_config_untangler/record_mapper_spec.rb
+++ b/spec/cspace_config_untangler/record_mapper_spec.rb
@@ -4,28 +4,31 @@ RSpec.describe CCU::RecordMapper do
   before(:all) do
     CCU.const_set('CONFIGDIR', 'spec/fixtures/files/6_0')
     @anthro_profile = CCU::Profile.new(profile: 'anthro',
-                                       rectypes: ['collectionobject', 'claim', 'taxon'],
-                                       structured_date_treatment: :collapse)
-    @anthro_co = @anthro_profile.rectypes.select{ |rt| rt.name == 'collectionobject' }.first
-    @anthro_claim = @anthro_profile.rectypes.select{ |rt| rt.name == 'claim' }.first
-    @anthro_taxon = @anthro_profile.rectypes.select{ |rt| rt.name == 'taxon' }.first
-    @rm_anthro_co = RecordMapping.new(profile: @anthro_profile, rectype: @anthro_co)
+                                       rectypes: ['collectionobject', 'claim', 'osteology', 'taxon'],
+                                       structured_date_treatment: :collapse)    
   end
 
-  describe RecordMapping do
-    describe '#hash' do
-      it 'returns record mapping hash' do
-        expect(@rm_anthro_co.hash).to be_a(Hash)
+  context 'anthro' do
+    context 'collectionobject' do
+      before(:all) do
+        @anthro_co = @anthro_profile.rectypes.select{ |rt| rt.name == 'collectionobject' }.first
+        @rm_anthro_co = RecordMapping.new(profile: @anthro_profile, rectype: @anthro_co)
+        @co_config = @rm_anthro_co.hash[:config]
       end
-    end
-  end
-
-  describe NamespaceUris do
-    context 'anthro' do
-      context 'collectionobject' do
+      describe RecordMapping do
+        describe '#hash[:config]' do
+          it "hash[:config][:service_type'] = 'object'" do
+            expect(@co_config[:service_type]).to eq('object')
+          end
+          it "hash[:config][:identifier_field'] = 'objectNumber'" do
+            expect(@co_config[:identifier_field]).to eq('objectNumber')
+          end
+        end
+      end
+      describe NamespaceUris do
         let(:result) { NamespaceUris.new(profile_config: @anthro_profile.config,
                                          rectype: 'collectionobject',
-                                         mapper_config: @rm_anthro_co.hash[:config]
+                                         mapper_config: @co_config
                                         ).hash }
 
         let(:expected) { {
@@ -41,31 +44,88 @@ RSpec.describe CCU::RecordMapper do
           expected.keys.each{ |k| expect(result[k]).to eq(expected[k]) }
         end
       end
+    end
 
-      context 'claim' do
-        let(:rm_anthro_claim) { RecordMapping.new(profile: @anthro_profile, rectype: @anthro_claim) }
-        let(:result) { NamespaceUris.new(profile_config: @anthro_profile.config,
-                                         rectype: 'claim',
-                                         mapper_config: rm_anthro_claim.hash[:config]
-                                        ).hash }
-
-        let(:expected) { {
-          'claims_nagpra' => 'http://collectionspace.org/services/claim/domain/nagpra',
-          'claims_common' => 'http://collectionspace.org/services/claim'
-        } }
-
-        it 'generates hash correctly' do
-          expected.keys.each{ |k| expect(result[k]).to eq(expected[k]) }
+    context 'claim' do
+      before(:all) do
+        @anthro_claim = @anthro_profile.rectypes.select{ |rt| rt.name == 'claim' }.first
+        @rm_anthro_claim = RecordMapping.new(profile: @anthro_profile, rectype: @anthro_claim)
+        @claim_config = @rm_anthro_claim.hash[:config]
+      end
+      describe RecordMapping do
+        describe '#hash[:config]' do
+          it "hash[:config][:service_type'] = 'procedure'" do
+            expect(@claim_config[:service_type]).to eq('procedure')
+          end
+          it "hash[:config][:identifier_field'] = 'claimNumber'" do
+            expect(@claim_config[:identifier_field]).to eq('claimNumber')
+          end
         end
       end
-      
-      context 'taxon' do
-        let(:rm_anthro_taxon) { RecordMapping.new(profile: @anthro_profile, rectype: @anthro_taxon) }
+      describe NamespaceUris do
+      let(:result) { NamespaceUris.new(profile_config: @anthro_profile.config,
+                                       rectype: 'claim',
+                                       mapper_config: @claim_config
+                                      ).hash }
+
+      let(:expected) { {
+        'claims_nagpra' => 'http://collectionspace.org/services/claim/domain/nagpra',
+        'claims_common' => 'http://collectionspace.org/services/claim'
+      } }
+
+      it 'generates hash correctly' do
+        expected.keys.each{ |k| expect(result[k]).to eq(expected[k]) }
+      end
+        end
+    end
+
+    context 'osteology' do
+      before(:all) do
+        @anthro_ost = @anthro_profile.rectypes.select{ |rt| rt.name == 'osteology' }.first
+        @rm_anthro_ost = RecordMapping.new(profile: @anthro_profile, rectype: @anthro_ost)
+        @ost_config = @rm_anthro_ost.hash[:config]
+      end
+      describe RecordMapping do
+        describe '#hash[:config]' do
+          it "hash[:config][:service_type'] = 'procedure'" do
+            expect(@ost_config[:service_type]).to eq('procedure')
+          end
+          it "hash[:config][:identifier_field'] = 'InventoryID'" do
+            expect(@ost_config[:identifier_field]).to eq('InventoryID')
+          end
+        end
+      end
+    end
+    
+    context 'taxon' do
+      before(:all) do
+        @anthro_taxon = @anthro_profile.rectypes.select{ |rt| rt.name == 'taxon' }.first
+        @rm_anthro_taxon = RecordMapping.new(profile: @anthro_profile, rectype: @anthro_taxon)
+        @taxon_config = @rm_anthro_taxon.hash[:config]
+      end
+      describe RecordMapping do
+        describe '#hash[:config]' do
+          it "[:service_type] = 'authority'" do
+            expect(@taxon_config[:service_type]).to eq('authority')
+          end
+          it "[:identifier_field] = 'shortIdentifier'" do
+            expect(@taxon_config[:identifier_field]).to eq('shortIdentifier')
+          end
+          it '[:authority_subtypes] returns array of hashes with keys: name, servicepathname' do
+            subtypes = @taxon_config[:authority_subtypes]
+            expected = [
+              { name: 'Local', servicepath_name: 'taxon' },
+              { name: 'Common', servicepath_name: 'common_ta' }
+            ]
+            expect(subtypes).to eq(expected)
+          end
+        end
+      end
+      describe NamespaceUris do
         let(:result) { NamespaceUris.new(profile_config: @anthro_profile.config,
                                          rectype: 'taxon',
-                                         mapper_config: rm_anthro_taxon.hash[:config]
+                                         mapper_config: @taxon_config
                                         ).hash }
-
         let(:expected) { {
           'taxon_common' => 'http://collectionspace.org/services/taxonomy'
         } }


### PR DESCRIPTION
Adds the following keys to the `config` section of the RecordMapper: 

- identifier_field (field to use as record ID)
- authority_subtypes (for authorities only) 