### PR TITLE
Authority mappers: null ns_uris

### DIFF
--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-citation.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "anthro",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-concept.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "anthro",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-location.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "anthro",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-organization.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "anthro",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-person.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "anthro",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-place.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "anthro",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/anthro/anthro_4_1_0-work.json
+++ b/data/mappers/release_6_1/anthro/anthro_4_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "anthro",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-citation.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-concept.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-location.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-organization.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-person.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-place.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/bonsai/bonsai_4_1_0-work.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "bonsai",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-citation.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-concept.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-location.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-organization.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-person.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-place.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/botgarden/botgarden_1_1_0-work.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_1_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "botgarden",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/core/core_6_1_0-citation.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "core",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/core/core_6_1_0-concept.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "core",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/core/core_6_1_0-location.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "core",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/core/core_6_1_0-organization.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "core",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/core/core_6_1_0-person.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "core",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/core/core_6_1_0-place.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "core",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/core/core_6_1_0-work.json
+++ b/data/mappers/release_6_1/core/core_6_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "core",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-citation.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "fcart",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-concept.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "fcart",
     "ns_uri": {
-      "concepts_common": null,
+      "concepts_common": "http://collectionspace.org/services/concept",
       "concepts_fineart": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-location.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "fcart",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-organization.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "fcart",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-person.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "fcart",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-place.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "fcart",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/fcart/fcart_3_0_0-work.json
+++ b/data/mappers/release_6_1/fcart/fcart_3_0_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "fcart",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-citation.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-concept.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-location.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-organization.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-person.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-place.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/herbarium/herbarium_1_1_0-work.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "herbarium",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-citation.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-concept.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-location.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-organization.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-person.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null,
       "persons_lhmc": "http://collectionspace.org/services//domain/lhmc"
     },

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-place.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "places_common": null,
+      "places_common": "http://collectionspace.org/services/place",
       "places_lhmc": "http://collectionspace.org/services//domain/lhmc"
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/lhmc/lhmc_3_1_0-work.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3_1_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "lhmc",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-citation.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "materials",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-concept.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "materials",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-location.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "materials",
     "ns_uri": {
-      "locations_common": null
+      "locations_common": "http://collectionspace.org/services/location"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-material.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-material.json
@@ -7,7 +7,7 @@
     "object_name": "Materialitem",
     "profile_basename": "materials",
     "ns_uri": {
-      "materials_common": null
+      "materials_common": "http://collectionspace.org/services/material"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-organization.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "materials",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/materials/materials_2_0_0-person.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "materials",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/materials/materials_2_0_0-place.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "materials",
     "ns_uri": {
-      "places_common": null
+      "places_common": "http://collectionspace.org/services/place"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/materials/materials_2_0_0-work.json
+++ b/data/mappers/release_6_1/materials/materials_2_0_0-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "materials",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-citation.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-citation.json
@@ -7,7 +7,7 @@
     "object_name": "Citation",
     "profile_basename": "publicart",
     "ns_uri": {
-      "citations_common": null
+      "citations_common": "http://collectionspace.org/services/citation"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-concept.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-concept.json
@@ -7,7 +7,7 @@
     "object_name": "Conceptitem",
     "profile_basename": "publicart",
     "ns_uri": {
-      "concepts_common": null
+      "concepts_common": "http://collectionspace.org/services/concept"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-location.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-location.json
@@ -7,7 +7,7 @@
     "object_name": "Locationitem",
     "profile_basename": "publicart",
     "ns_uri": {
-      "locations_common": null,
+      "locations_common": "http://collectionspace.org/services/location",
       "locations_publicart": "http://collectionspace.org/services//domain/publicart"
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-organization.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-organization.json
@@ -7,7 +7,7 @@
     "object_name": "Organization",
     "profile_basename": "publicart",
     "ns_uri": {
-      "organizations_common": null,
+      "organizations_common": "http://collectionspace.org/services/organization",
       "contacts_common": null,
       "organizations_publicart": "http://collectionspace.org/services//domain/publicart"
     },

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-person.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-person.json
@@ -7,7 +7,7 @@
     "object_name": "Person",
     "profile_basename": "publicart",
     "ns_uri": {
-      "persons_common": null,
+      "persons_common": "http://collectionspace.org/services/person",
       "contacts_common": null,
       "persons_publicart": "http://collectionspace.org/services//domain/publicart"
     },

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-place.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-place.json
@@ -7,7 +7,7 @@
     "object_name": "Placeitem",
     "profile_basename": "publicart",
     "ns_uri": {
-      "places_common": null,
+      "places_common": "http://collectionspace.org/services/place",
       "places_publicart": "http://collectionspace.org/services//domain/publicart"
     },
     "identifier_field": "shortIdentifier",

--- a/data/mappers/release_6_1/publicart/publicart_2_0_1-work.json
+++ b/data/mappers/release_6_1/publicart/publicart_2_0_1-work.json
@@ -7,7 +7,7 @@
     "object_name": "Workitem",
     "profile_basename": "publicart",
     "ns_uri": {
-      "works_common": null
+      "works_common": "http://collectionspace.org/services/work"
     },
     "identifier_field": "shortIdentifier",
     "authority_subtypes": [

--- a/lib/cspace_config_untangler.rb
+++ b/lib/cspace_config_untangler.rb
@@ -1,5 +1,6 @@
 # standard library
 require 'csv'
+require 'fileutils'
 require 'json'
 require 'logger'
 require 'pp'

--- a/lib/cspace_config_untangler/command_line.rb
+++ b/lib/cspace_config_untangler/command_line.rb
@@ -54,7 +54,7 @@ module CspaceConfigUntangler
     def list_rec_types
       get_profiles.each{ |p|
         puts "\n#{p}:"
-        puts CCU::Profile.new(p).rectypes.map{ |e| "  #{e.name}" }
+        puts CCU::Profile.new(profile: p).rectypes.map{ |e| "  #{e.name}" }
       }
     end
 
@@ -76,12 +76,14 @@ module CspaceConfigUntangler
       get_profiles.each do |profile|
         puts "Writing mappers for #{profile}..."
         p = CCU::Profile.new(profile: profile, rectypes: rts, structured_date_treatment: :collapse)
+        dir_path = "#{options[:outputdir]}/#{p.name}"
+        FileUtils.mkdir_p(dir_path)
         p.rectypes.each do |rt|
           puts "  ...#{rt.name}"
           recmapper = RecordMapping.new(profile: p,
                                         rectype: rt
                                        )
-          path = "#{options[:outputdir]}/#{p.name}-#{rt.name}.json"
+          path = "#{dir_path}/#{p.name}-#{rt.name}.json"
           recmapper.to_json(output: path)
         end
       end
@@ -108,7 +110,7 @@ module CspaceConfigUntangler
     def extensions_by_profile
       exts = {}
       get_profiles.each{ |p|
-        CCU::Profile.new(p).extensions.each{ |ext|
+        CCU::Profile.new(profile: p).extensions.each{ |ext|
           if exts.has_key?(ext)
             exts[ext] << p
           else
@@ -126,7 +128,7 @@ module CspaceConfigUntangler
     def write_field_defs
       field_defs = []
       get_profiles.each {|profile|
-        p = CCU::Profile.new(profile)
+        p = CCU::Profile.new(profile: profile)
         if options[:rectype] == 'all'
           rts = p.rectypes.map{ |rt| rt.name }
         else
@@ -157,7 +159,7 @@ module CspaceConfigUntangler
     def write_form_fields
       form_fields = []
       get_profiles.each {|profile|
-        p = CCU::Profile.new(profile)
+        p = CCU::Profile.new(profile: profile)
         if options[:rectype] == 'all'
           rts = p.rectypes.map{ |rt| rt.name }
         else
@@ -211,7 +213,7 @@ The full schema_path should be unique within a record type. Non-unique fields ar
   LONGDESC
     def report_nonunique_fields
       get_profiles.each {|profile|
-        p = CCU::Profile.new(profile)
+        p = CCU::Profile.new(profile: profile)
         h = {}
         p.nonunique_fields.each{ |rt, fields| h[rt] = fields if fields.length > 0 }
         h.each{ |rt, fields| fields.each{ |f| puts "#{@name} - #{rt} - #{f}" } }

--- a/lib/cspace_config_untangler/record_mapper.rb
+++ b/lib/cspace_config_untangler/record_mapper.rb
@@ -116,10 +116,9 @@ module CspaceConfigUntangler
           .reject{ |k| k == 'ns2:collectionspace_core' || k == 'ns2:account_permission' }
           .each do |ns|
             objname = @mconfig[:object_name].downcase unless @mconfig[:service_type] == 'authority'
-
             if ns == "ns2:#{@mconfig[:document_name]}_common"
               if @mconfig[:service_type] == 'authority'
-                uri = @config.dig('recordTypes', @mconfig[:document_name], 'fields', 'document', ns, 'csid', '[config]',
+                uri = @config.dig('recordTypes', @rectype, 'fields', 'document', ns, 'csid', '[config]',
                                   'extensionParentConfig', 'service', 'ns')
               else
                 uri = "http://collectionspace.org/services/#{objname}"

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end

--- a/spec/cspace_config_untangler/record_mapper_spec.rb
+++ b/spec/cspace_config_untangler/record_mapper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CCU::RecordMapper do
     before(:all) do
       @anthro_profile = CCU::Profile.new(profile: 'anthro_4_1_0',
                                          rectypes: ['collectionobject', 'claim',
-                                                    'osteology', 'taxon'],
+                                                    'osteology', 'place', 'taxon'],
                                          structured_date_treatment: :collapse)
     end
     context 'collectionobject' do
@@ -125,6 +125,27 @@ RSpec.describe CCU::RecordMapper do
       end
     end
     
+    context 'place' do
+      before(:all) do
+        @rectype = @anthro_profile.rectypes.select{ |rt| rt.name == 'place' }.first
+        @mapper = RecordMapping.new(profile: @anthro_profile, rectype: @rectype)
+        @config = @mapper.hash[:config]
+      end
+      describe NamespaceUris do
+        let(:result) { NamespaceUris.new(profile_config: @anthro_profile.config,
+                                         rectype: 'place',
+                                         mapper_config: @config
+                                        ).hash }
+        let(:expected) { {
+          'places_common' => 'http://collectionspace.org/services/place'
+        } }
+
+        it 'generates hash correctly' do
+          expected.keys.each{ |k| expect(result[k]).to eq(expected[k]) }
+        end
+      end
+    end
+
     context 'taxon' do
       before(:all) do
         @anthro_taxon = @anthro_profile.rectypes.select{ |rt| rt.name == 'taxon' }.first


### PR DESCRIPTION
Fixes issue where RecordMapper config/ns_uris hash was null in authority record types. 

Also writes mappers to subdirectory (name of profile) within given output directory