### PR TITLE
Missing id field

### DIFF
--- a/cspace_config_untangler.gemspec
+++ b/cspace_config_untangler.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0.1"
   spec.add_development_dependency "rspec", "~> 3.0"
 
+  spec.add_runtime_dependency "facets", ">= 3.1.0"
   spec.add_runtime_dependency "http", ">= 4.4.1"
   spec.add_runtime_dependency "nokogiri", ">= 1.10.9"
   spec.add_runtime_dependency "thor", ">= 0.20.3"

--- a/lib/cspace_config_untangler.rb
+++ b/lib/cspace_config_untangler.rb
@@ -8,6 +8,7 @@ require 'yaml'
 
 # external gems
 require 'bundler/setup'
+require 'facets/kernel/blank'
 require 'http'
 require 'nokogiri'
 require 'pry'

--- a/lib/cspace_config_untangler/command_line.rb
+++ b/lib/cspace_config_untangler/command_line.rb
@@ -89,6 +89,25 @@ module CspaceConfigUntangler
       end
     end
 
+    desc 'report_mappers_without_identifier_field', 'outputs to screen a list of mappers where no identifier_field is set'
+    option :rectypes, :desc => 'comma-delimited (no spaces) list of record types to write mappers for; if blank, will process all record types in profile', :default => ''
+    def report_mappers_without_identifier_field
+      puts 'Record mappers without a config/identifier_field value'
+      rts = options[:rectypes].split(',').map(&:strip)
+      get_profiles.each do |profile|
+#        puts profile
+        p = CCU::Profile.new(profile: profile, rectypes: rts, structured_date_treatment: :collapse)
+        p.rectypes.each do |rt|
+#          puts rt.name
+          recmapper = RecordMapping.new(profile: p,
+                                        rectype: rt
+                                       ).hash
+          id_field = recmapper[:config][:identifier_field]
+          puts "#{profile} -- #{rt.name}" if id_field.blank?
+        end
+      end
+    end
+
     desc 'write_csv_templates', 'write batch import CSV templates for given (or all) record types in the given profiles'
     option :rectypes, :desc => 'comma-delimited (no spaces) list of record types to create templates for; if blank, will process all record types in profile', :default => ''
     option :outputdir, :desc => 'path to output directory. File name will be: profile-rectype_template.csv', :default => 'data/templates'

--- a/lib/cspace_config_untangler/field_map.rb
+++ b/lib/cspace_config_untangler/field_map.rb
@@ -6,8 +6,8 @@ module CspaceConfigUntangler
       ::FieldMapping = CspaceConfigUntangler::FieldMap::FieldMapping
       include CCU::TrackAttributes
       attr_reader :fieldname, :transforms, :source_type, :namespace, :xpath, :data_type,
-        :required, :repeats, :in_repeating_group, :opt_list_values
-      attr_accessor :datacolumn
+        :repeats, :in_repeating_group, :opt_list_values
+      attr_accessor :datacolumn, :required
       def initialize(field:, datacolumn:, transforms: {}, source_type:)
         @fieldname = field.name
         @namespace = field.ns.sub('ns2:', '')

--- a/lib/cspace_config_untangler/record_mapper.rb
+++ b/lib/cspace_config_untangler/record_mapper.rb
@@ -11,7 +11,7 @@ module CspaceConfigUntangler
       def initialize(profile:, rectype:)
         @profile = profile
         @rectype = rectype
-        @mappings = @rectype.mappings
+        @mappings = @rectype.batch_mappings
         @config = @profile.config
         @hash = {}
         build_hash
@@ -55,7 +55,7 @@ module CspaceConfigUntangler
         end
         result
       end
-      
+
       def get_id_field
         case @hash[:config][:service_type]
         when 'object'
@@ -67,10 +67,9 @@ module CspaceConfigUntangler
           if mapping.length == 1
             id_field = mapping.first.fieldname
           elsif mapping.length > 1
+            # osteology has 3 required fields, but only the ID is suitable for use here
             id_field = 'InventoryID' if @rectype.name == 'osteology'
-          elsif mapping.empty?
-            id_field = 'loanOutNumber'if @profile.name.start_with?('botgarden') &&
-              @rectype.name == 'loanout'
+            id_field = 'movementReferenceNumber' if @rectype.name == 'movement' && !@profile.name.start_with?('botgarden')
           end
         end
         id_field

--- a/lib/cspace_config_untangler/record_types.rb
+++ b/lib/cspace_config_untangler/record_types.rb
@@ -79,6 +79,29 @@ module CspaceConfigUntangler
       end
       mappings
     end
+
+    # sets up "faux-required" fields for record types that do not have any required fields
+    #   some unique ID field is required for batch import/processing
+    def batch_mappings
+      mappings = self.mappings
+      if @name == 'movement'
+        unless @profile.name.start_with?('botgarden')
+          mapping = mappings.select{ |m| m.fieldname == 'movementReferenceNumber' }.first
+          mapping.required = 'y'
+        end
+      end
+      if @profile.name.start_with?('botgarden')
+        if @name == 'loanout'
+          mapping = mappings.select{ |m| m.fieldname == 'loanOutNumber' }.first
+          mapping.required = 'y'
+        end
+        if @name == 'objectexit'
+          mapping = mappings.select{ |m| m.fieldname == 'exitNumber' }.first
+          mapping.required = 'y'
+        end
+      end
+      mappings
+    end
     
     private
 

--- a/lib/cspace_config_untangler/template.rb
+++ b/lib/cspace_config_untangler/template.rb
@@ -12,7 +12,7 @@ module CspaceConfigUntangler
         @profile = profile
         @rectype = rectype
         @config = @profile.config
-        @mappings = @rectype.mappings
+        @mappings = @rectype.batch_mappings
         @csvdata = []
         build_template
       end

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "0.3.7"
+  VERSION = "0.4.0"
 end

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "0.4.0"
+  VERSION = "1.0.0"
 end

--- a/spec/cspace_config_untangler/record_type_spec.rb
+++ b/spec/cspace_config_untangler/record_type_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe CCU::RecordType do
   before(:all) do
     CCU.const_set('CONFIGDIR', 'spec/fixtures/files/6_0')
     @core_profile = CCU::Profile.new(profile: 'core', rectypes: ['collectionobject'])
-    @anthro_profile = CCU::Profile.new(profile: 'anthro', rectypes: ['collectionobject'])
+    @anthro_profile = CCU::Profile.new(profile: 'anthro', rectypes: %w[collectionobject movement])
     @bg_profile = CCU::Profile.new(profile: 'botgarden', rectypes: ['collectionobject'])
     @core_co = @core_profile.rectypes[0]
     @anthro_co = @anthro_profile.rectypes[0]
+    @anthro_movement = @anthro_profile.rectypes[1]
     @bg_co = @bg_profile.rectypes[0]
   end
   describe '.new' do
@@ -78,6 +79,33 @@ RSpec.describe CCU::RecordType do
           it 'columnnames: fieldLocVerbatim localityGroup_fieldLocVerbatim' do
             result = @mappings.select{ |m| m.fieldname == 'fieldLocVerbatim' }.map{ |m| m.datacolumn }.sort
             expect(result).to eq(%w[fieldLocVerbatim localityGroup_fieldLocVerbatim])
+          end
+        end
+      end
+      context 'movement recordtype' do
+        before(:all) do
+          @mappings = @anthro_movement.mappings
+        end
+        context 'fieldname = movementReferenceNumber' do
+          it 'is not required' do
+            result = @mappings.select{ |m| m.fieldname == 'movementReferenceNumber' }.map{ |m| m.required }.sort
+            expect(result).to eq(%w[n])
+          end
+        end
+      end
+    end
+  end
+
+    describe '.batch_mappings' do
+    context 'anthro profile' do
+      context 'movement recordtype' do
+        before(:all) do
+          @mappings = @anthro_movement.batch_mappings
+        end
+        context 'fieldname = movementReferenceNumber' do
+          it 'is required' do
+            result = @mappings.select{ |m| m.fieldname == 'movementReferenceNumber' }.map{ |m| m.required }.sort
+            expect(result).to eq(%w[y])
           end
         end
       end

--- a/spec/cspace_config_untangler/template_spec.rb
+++ b/spec/cspace_config_untangler/template_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe CCU::Template::CsvTemplate do
+
+  before(:all) do
+    CCU.const_set('CONFIGDIR', 'spec/fixtures/files/6_1')
+    @anthro_profile = CCU::Profile.new(profile: 'anthro_4_1_0', rectypes: %w[movement])
+    @anthro_movement = @anthro_profile.rectypes[0]
+    @anthro_movement_template = CsvTemplate.new(profile: @anthro_profile, rectype: @anthro_movement)
+  end
+  describe '.csvdata' do
+    it 'correctly reports faux-requiredness' do
+      headers = @anthro_movement_template.csvdata[6]
+      req = @anthro_movement_template.csvdata[1]
+      field_index = headers.index('movementReferenceNumber')
+      expect(req[field_index]).to eq('y')
+    end
+  end
+end #RSpec


### PR DESCRIPTION
- Adds command line function to report record types that do not get assigned an identifier_field. For the community profiles, these are currently limited to botgarden movement and pottag, which do not contain any fields suitable for use as an identifier
- Adds `RecordType.batch_mappings` method which assigns "required = y" to suitable identifier field when said field is not required by a record type (e.g. movement records in all profiles except botgarden will faux-require `movementReferenceNumber`. The faux-required value is only output in JSON RecordMappers for use by `collectionspace-mapper` and CSV data templates 