### PR TITLE
Add required = 'y in template' option to FieldMapping

### DIFF
--- a/data/mappers/release_6_1/anthro/anthro_4-1-2_authorityhierarchy.json
+++ b/data/mappers/release_6_1/anthro/anthro_4-1-2_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -49,7 +49,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -89,7 +89,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/anthro/anthro_4-1-2_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/anthro/anthro_4-1-2_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -57,7 +57,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -133,7 +133,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/anthro/anthro_4-1-2_objecthierarchy.json
+++ b/data/mappers/release_6_1/anthro/anthro_4-1-2_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/bonsai/bonsai_4-1-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4-1-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -49,7 +49,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -86,7 +86,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/bonsai/bonsai_4-1-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4-1-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -55,7 +55,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -129,7 +129,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/bonsai/bonsai_4-1-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/bonsai/bonsai_4-1-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/botgarden/botgarden_2-0-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_2-0-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -49,7 +49,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -89,7 +89,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/botgarden/botgarden_2-0-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_2-0-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -53,7 +53,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -125,7 +125,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/botgarden/botgarden_2-0-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/botgarden/botgarden_2-0-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json
+++ b/data/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -48,7 +48,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -83,7 +83,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/core/core_6-1-0_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/core/core_6-1-0_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -55,7 +55,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -129,7 +129,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/core/core_6-1-0_objecthierarchy.json
+++ b/data/mappers/release_6_1/core/core_6-1-0_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/fcart/fcart_3-0-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/fcart/fcart_3-0-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -48,7 +48,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -84,7 +84,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/fcart/fcart_3-0-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/fcart/fcart_3-0-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -55,7 +55,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -129,7 +129,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/fcart/fcart_3-0-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/fcart/fcart_3-0-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/herbarium/herbarium_1-1-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1-1-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -49,7 +49,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -87,7 +87,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/herbarium/herbarium_1-1-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1-1-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -52,7 +52,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -123,7 +123,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/herbarium/herbarium_1-1-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/herbarium/herbarium_1-1-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/lhmc/lhmc_3-1-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3-1-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -48,7 +48,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -83,7 +83,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/lhmc/lhmc_3-1-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3-1-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -55,7 +55,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -129,7 +129,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/lhmc/lhmc_3-1-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/lhmc/lhmc_3-1-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/materials/materials_2-0-0_authorityhierarchy.json
+++ b/data/mappers/release_6_1/materials/materials_2-0-0_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -49,7 +49,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -85,7 +85,7 @@
         "work_shared"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/materials/materials_2-0-0_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/materials/materials_2-0-0_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -50,7 +50,7 @@
         "uoc"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -119,7 +119,7 @@
         "uoc"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/materials/materials_2-0-0_objecthierarchy.json
+++ b/data/mappers/release_6_1/materials/materials_2-0-0_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/data/mappers/release_6_1/publicart/publicart_2-0-1_authorityhierarchy.json
+++ b/data/mappers/release_6_1/publicart/publicart_2-0-1_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -48,7 +48,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -81,7 +81,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",

--- a/data/mappers/release_6_1/publicart/publicart_2-0-1_nonhierarchicalrelationship.json
+++ b/data/mappers/release_6_1/publicart/publicart_2-0-1_nonhierarchicalrelationship.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -55,7 +55,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item1_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",
@@ -129,7 +129,7 @@
         "valuationcontrols"
       ],
       "datacolumn": "item2_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "objectCsid",

--- a/data/mappers/release_6_1/publicart/publicart_2-0-1_objecthierarchy.json
+++ b/data/mappers/release_6_1/publicart/publicart_2-0-1_objecthierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "objectNumber"
   },
   "docstructure": {
@@ -52,26 +52,6 @@
       ],
       "datacolumn": "narrower_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "subjectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "subjectdocumenttype",
-      "required": "y",
-      "to_template": false
     },
     {
       "fieldname": "relationshipType",
@@ -138,26 +118,6 @@
       ],
       "datacolumn": "broader_object_number",
       "required": "y"
-    },
-    {
-      "fieldname": "objectDocumentType",
-      "transforms": {
-      },
-      "source_type": "na",
-      "source_name": null,
-      "namespace": "relations_common",
-      "xpath": [
-
-      ],
-      "data_type": "string",
-      "repeats": "n",
-      "in_repeating_group": "n",
-      "opt_list_values": [
-
-      ],
-      "datacolumn": "objectdocumenttype",
-      "required": "y",
-      "to_template": false
     }
   ]
 }

--- a/lib/cspace_config_untangler/authority_hierarchy.rb
+++ b/lib/cspace_config_untangler/authority_hierarchy.rb
@@ -35,7 +35,7 @@ module CspaceConfigUntangler
         ns_uri: {
           relations_common: 'http://collectionspace.org/services/relation'
         },
-        identifier_field: 'csid',
+        identifier_field: 'subjectCsid',
         search_field: 'term'
       }
     end
@@ -66,7 +66,7 @@ module CspaceConfigUntangler
           in_repeating_group: 'n',
           opt_list_values: @profile.authority_types,
           datacolumn: 'term_type',
-          required: 'y'
+          required: 'y in template'
         },
         {
           fieldname: 'termSubType',
@@ -80,8 +80,9 @@ module CspaceConfigUntangler
           in_repeating_group: 'n',
           opt_list_values: @profile.authority_subtypes,
           datacolumn: 'term_subtype',
-          required: 'y'
-        },{
+          required: 'y in template'
+        },
+        {
           fieldname: 'subjectCsid',
           transforms: { special: [:term_to_csid] },
           source_type: 'na',
@@ -95,21 +96,6 @@ module CspaceConfigUntangler
           datacolumn: 'narrower_term',
           required: 'y'
           },
-        # {
-        #   fieldname: 'subjectDocumentType',
-        #   transforms: {},
-        #   source_type: 'na',
-        #   source_name: nil,
-        #   namespace: 'relations_common',
-        #   xpath: [],
-        #   data_type: 'string',
-        #   repeats: 'n',
-        #   in_repeating_group: 'n',
-        #   opt_list_values: [],
-        #   datacolumn: 'subjectdocumenttype',
-        #   required: 'y',
-        #   to_template: false
-        # },
         {
           fieldname: 'relationshipType',
           transforms: {},
@@ -139,21 +125,6 @@ module CspaceConfigUntangler
           datacolumn: 'broader_term',
           required: 'y'
         },
-        # {
-        #   fieldname: 'objectDocumentType',
-        #   transforms: {},
-        #   source_type: 'na',
-        #   source_name: nil,
-        #   namespace: 'relations_common',
-        #   xpath: [],
-        #   data_type: 'string',
-        #   repeats: 'n',
-        #   in_repeating_group: 'n',
-        #   opt_list_values: [],
-        #   datacolumn: 'objectdocumenttype',
-        #   required: 'y',
-        #   to_template: false
-        # }
       ]
     end
   end

--- a/lib/cspace_config_untangler/non_hierarchical_relationship.rb
+++ b/lib/cspace_config_untangler/non_hierarchical_relationship.rb
@@ -35,7 +35,7 @@ module CspaceConfigUntangler
         ns_uri: {
           relations_common: 'http://collectionspace.org/services/relation'
         },
-        identifier_field: 'csid',
+        identifier_field: 'subjectCsid',
         search_field: 'term'
       }
     end
@@ -44,10 +44,8 @@ module CspaceConfigUntangler
       {
         relations_common: {
           subjectCsid: {},
-          #subjectDocumentType: {},
           relationshipType: {},
           objectCsid: {},
-          #objectDocumentType: {}
         }
       }
     end
@@ -66,7 +64,7 @@ module CspaceConfigUntangler
           in_repeating_group: 'n',
           opt_list_values: @profile.object_and_procedures,
           datacolumn: 'item1_type',
-          required: 'y'
+          required: 'y in template'
         },
         {
           fieldname: 'subjectCsid',
@@ -109,7 +107,7 @@ module CspaceConfigUntangler
           in_repeating_group: 'n',
           opt_list_values: @profile.object_and_procedures,
           datacolumn: 'item2_type',
-          required: 'y'
+          required: 'y in template'
         },
         {
           fieldname: 'objectCsid',

--- a/lib/cspace_config_untangler/object_hierarchy.rb
+++ b/lib/cspace_config_untangler/object_hierarchy.rb
@@ -39,7 +39,7 @@ module CspaceConfigUntangler
         ns_uri: {
           relations_common: 'http://collectionspace.org/services/relation'
         },
-        identifier_field: 'csid',
+        identifier_field: 'subjectCsid',
         search_field: 'objectNumber'
       }
     end
@@ -72,21 +72,6 @@ module CspaceConfigUntangler
           opt_list_values: [],
           datacolumn: 'narrower_object_number',
           required: 'y'
-        },
-        {
-          fieldname: 'subjectDocumentType',
-          transforms: {},
-          source_type: 'na',
-          source_name: nil,
-          namespace: 'relations_common',
-          xpath: [],
-          data_type: 'string',
-          repeats: 'n',
-          in_repeating_group: 'n',
-          opt_list_values: [],
-          datacolumn: 'subjectdocumenttype',
-          required: 'y',
-          to_template: false
         },
         {
           fieldname: 'relationshipType',
@@ -130,21 +115,6 @@ module CspaceConfigUntangler
           opt_list_values: [],
           datacolumn: 'broader_object_number',
           required: 'y'
-        },
-        {
-          fieldname: 'objectDocumentType',
-          transforms: {},
-          source_type: 'na',
-          source_name: nil,
-          namespace: 'relations_common',
-          xpath: [],
-          data_type: 'string',
-          repeats: 'n',
-          in_repeating_group: 'n',
-          opt_list_values: [],
-          datacolumn: 'objectdocumenttype',
-          required: 'y',
-          to_template: false
         }
       ]
     end

--- a/lib/cspace_config_untangler/template.rb
+++ b/lib/cspace_config_untangler/template.rb
@@ -38,7 +38,7 @@ module CspaceConfigUntangler
       private
 
       def build_template
-        requiredfields = @mappings.select{ |m| m[:required] == 'y' }
+        requiredfields = @mappings.select{ |m| m[:required].start_with?('y') }
         otherfields = @mappings.select{ |m| m[:required] == 'n' }
         instruct = ['Before importing CSV, delete initial column and rows above the CSVHEADER row']
         required = ['REQUIRED']
@@ -52,7 +52,7 @@ module CspaceConfigUntangler
         [requiredfields, otherfields].each do |fieldmappings|
           fieldmappings.each do |mapping|
             instruct << ''
-            required << mapping[:required]
+            required << mapping[:required].sub(' in template', '')
             datatype << mapping[:data_type]
             repeats << mapping[:repeats]
             mapping[:in_repeating_group].start_with?('n') ? group << '' : group << mapping[:xpath].join(' < ')

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "1.8.1"
+  VERSION = "1.8.2"
 end


### PR DESCRIPTION
This is used by special record types for relationships.

These record types do not actually need object/subject types indicated
for successful mapping. They do need to be specified in order to look
up the CSID of the subject/object, however. So they must be in the CSV
template (and should be marked as required there), but are not
required after the data has been transformed for mapping (i.e.
terms/obj numbers replaced with CSIDs)

Also, whatever is listed as "identifier_field" in the RecordMapper
will be treated as a required field for mapping. Since users should
not have to specify an id for a relationship record, I've set this to
subjectCsid in all cases, though that is not actually correct.