### PR TITLE
Ignore export in a profile's record types list.

### DIFF
--- a/lib/cspace_config_untangler/profile.rb
+++ b/lib/cspace_config_untangler/profile.rb
@@ -181,7 +181,7 @@ module CspaceConfigUntangler
     end
     
     def get_rectypes(rectypes)
-      remove = %w[account all authrole authority batch batchinvocation blob contact idgenerator object procedure relation report reportinvocation structureddates vocabulary]
+      remove = %w[account all authrole authority batch batchinvocation blob contact export idgenerator object procedure relation report reportinvocation structureddates vocabulary]
       @rectypes_all = @config['recordTypes'].keys - remove
 
       # if no rectypes are given, process all of them

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "1.8.3"
+  VERSION = "1.8.4"
 end


### PR DESCRIPTION
I believe export was added to support ad-hoc reporting in 6.1. If it
is not excluded from treatment as a record type, it causes field
extraction to fail.