### PR TITLE
Mapper manifest storage and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ Gemfile.lock
 /.yardoc
 /_yardoc/
 /coverage/
-/doc/
 /pkg/
 /spec/reports/
 *.log

--- a/data/mapper_manifests/community_profile_mappers_release_6_1.json
+++ b/data/mapper_manifests/community_profile_mappers_release_6_1.json
@@ -1,0 +1,2195 @@
+{
+  "mappers": [
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-material.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_conservation.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_media.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_organization-ulan.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_loanin.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_movement.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_exhibition.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "claim",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_claim.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "taxon-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_taxon-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_intake.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "taxon-common",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_taxon-common.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-activity.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_group.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_citation-worldcat.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_work-cona.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_location-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-ethnographic-culture",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-ethnographic-culture.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_person-ulan.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_valuation.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_acquisition.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_collectionobject.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-associated.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-archaeological-culture",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-archaeological-culture.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_uoc.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_person-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_citation-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-ethnographic-file-code",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-ethnographic-file-code.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_objecthierarchy.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_authorityhierarchy.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "osteology",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_osteology.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_organization-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-occasion.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_conditioncheck.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_location-offsite.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_objectexit.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_place-local.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_loanout.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-nomenclature.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_place-tgn.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_work-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_work-cona.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_media.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-associated.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_place-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_location-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_valuation.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_organization-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_location-offsite.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-occasion.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_exhibition.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_conservation.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_group.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_objectexit.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_collectionobject.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_citation-worldcat.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_movement.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_work-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_acquisition.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_objecthierarchy.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_uoc.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_person-ulan.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_loanout.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_place-tgn.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_conditioncheck.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-ethnographic-culture",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-ethnographic-culture.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_citation-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-activity.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_organization-ulan.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_loanin.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_person-local.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-material.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_intake.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_movement.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_conservation.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_group.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_objecthierarchy.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "material-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_material-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_concept-nomenclature.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_media.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_location-offsite.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "person-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_person-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "concept-shared-material-classification",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_concept-shared-material-classification.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_concept-occasion.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_citation-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_acquisition.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_uoc.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_location-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "organization-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_organization-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "work-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_work-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_loanout.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_authorityhierarchy.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_person-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_organization-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_objectexit.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "material-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_material-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_work-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "place-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_place-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "concept-material-classification",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_concept-material-classification.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_place-local.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_collectionobject.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "citation-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_citation-shared.json"
+    },
+    {
+      "profile": "materials",
+      "version": "2-0-0",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/materials/materials_2-0-0_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-associated.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_collectionobject.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_loanout.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_work-cona.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_conservation.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_location-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_valuation.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_place-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_organization-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_media.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-activity.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_work-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_objectexit.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_movement.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_group.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-material.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_person-ulan.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_exhibition.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_person-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_intake.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-nomenclature.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_place-tgn.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_location-offsite.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_conditioncheck.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_loanin.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-occasion.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_citation-worldcat.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_acquisition.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_citation-local.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_organization-ulan.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_uoc.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_objecthierarchy.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "place-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_place-shared.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_uoc.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_organization-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_valuation.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_citation-worldcat.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_location-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_exhibition.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_acquisition.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_intake.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_location-offsite.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_concept-occasion.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_loanin.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_person-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_objectexit.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_group.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_work-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_citation-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "organization-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_organization-shared.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_concept-material.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_conservation.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "person-shared",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_person-shared.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_place-local.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_collectionobject.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_media.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_conditioncheck.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "concept-work-type",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_concept-work-type.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_loanout.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_objecthierarchy.json"
+    },
+    {
+      "profile": "publicart",
+      "version": "2-0-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/publicart/publicart_2-0-1_movement.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_uoc.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_collectionobject.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_objectexit.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_citation-worldcat.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_valuation.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_place-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_work-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_objecthierarchy.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_media.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_work-cona.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-class",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-class.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_loanout.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_intake.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-activity.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_location-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_organization-ulan.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-associated.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_organization-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_person-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_group.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-material.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_place-tgn.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "pottag",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_pottag.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_citation-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_location-offsite.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_person-ulan.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_movement.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-research-project",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-research-project.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-occasion.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "taxon-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_taxon-local.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_conditioncheck.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "propagation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_propagation.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "concept-conservation-category",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_concept-conservation-category.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "botgarden",
+      "version": "2-0-1",
+      "type": "taxon-common",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/botgarden/botgarden_2-0-1_taxon-common.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_loanout.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_organization-ulan.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_conditioncheck.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_conservation.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_place-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_work-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_movement.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_citation-worldcat.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_objectexit.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_place-tgn.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_citation-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_concept-occasion.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_location-offsite.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_media.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_person-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_person-ulan.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_exhibition.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_concept-activity.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_objecthierarchy.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_concept-material.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_uoc.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_location-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_acquisition.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_intake.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_valuation.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_group.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_organization-local.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_collectionobject.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_work-cona.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_concept-associated.json"
+    },
+    {
+      "profile": "lhmc",
+      "version": "3-1-1",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/lhmc/lhmc_3-1-1_loanin.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_concept-material.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "conservation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_conservation.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_intake.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_location-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "taxon-common",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_taxon-common.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_organization-ulan.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_loanin.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_movement.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_concept-activity.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_concept-associated.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_place-tgn.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_organization-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_exhibition.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_citation-worldcat.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_place-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_collectionobject.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_group.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_nonhierarchicalrelationship.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "objectexit",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_objectexit.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_work-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_uoc.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_person-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_objecthierarchy.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "taxon-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_taxon-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_conditioncheck.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_citation-local.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_concept-occasion.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_person-ulan.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_loanout.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_media.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_work-cona.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_location-offsite.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_valuation.json"
+    },
+    {
+      "profile": "bonsai",
+      "version": "4-1-1",
+      "type": "acquisition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/bonsai/bonsai_4-1-1_acquisition.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "place-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_place-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-nomenclature",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-nomenclature.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "place-tgn",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_place-tgn.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "exhibition",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_exhibition.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "location-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_location-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "location-offsite",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_location-offsite.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-occasion",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-occasion.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "person-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_person-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "loanout",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_loanout.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "uoc",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_uoc.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "work-cona",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_work-cona.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "loanin",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_loanin.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "group",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_group.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "organization-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_organization-ulan.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-material",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-material.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-label",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-label.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "valuation",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_valuation.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-activity",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-activity.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "citation-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_citation-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "person-ulan",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_person-ulan.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "intake",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_intake.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "taxon-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_taxon-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "movement",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_movement.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "media",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_media.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "taxon-common",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_taxon-common.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "citation-worldcat",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_citation-worldcat.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_concept-associated.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "conditioncheck",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_conditioncheck.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "objecthierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_objecthierarchy.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_collectionobject.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "work-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_work-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "authorityhierarchy",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_authorityhierarchy.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "organization-local",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_organization-local.json"
+    },
+    {
+      "profile": "herbarium",
+      "version": "1-1-1",
+      "type": "nonhierarchicalrelationship",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/herbarium/herbarium_1-1-1_nonhierarchicalrelationship.json"
+    }
+  ]
+}

--- a/data/mapper_manifests/dev_mappers.json
+++ b/data/mapper_manifests/dev_mappers.json
@@ -1,0 +1,46 @@
+{
+  "mappers": [
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_collectionobject.json"
+    },
+    {
+      "profile": "anthro",
+      "version": "4-1-2",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/anthro/anthro_4-1-2_concept-associated.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_concept-associated.json"
+    },
+    {
+      "profile": "fcart",
+      "version": "3-0-1",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/fcart/fcart_3-0-1_collectionobject.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "concept-associated",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_concept-associated.json"
+    },
+    {
+      "profile": "core",
+      "version": "6-1-0",
+      "type": "collectionobject",
+      "enabled": true,
+      "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mappers/release_6_1/core/core_6-1-0_collectionobject.json"
+    }
+  ]
+}

--- a/doc/generating_mappers_and_mapper_manifest.adoc
+++ b/doc/generating_mappers_and_mapper_manifest.adoc
@@ -1,0 +1,32 @@
+= Generating mappers and mapper manifest
+
+mapper:: Instructions/data needed in order to convert flat data into CSpace XML, in a structured JSON document. Each record type in a profile has its own mapper. The `collectionspace-mapper` application calls these ``RecordMapper``s.
+mapper manifest:: A list of available mappers for use in configuring `cspace-batch-import`.
+
+The following instructions assume:
+
+- you want to generate mappers and a mapper manifest for all record types in the current versions of all community profiles; and
+- the current configs for the community profiles are in your `data/configs` directory
+
+== Create the mappers
+This will create mappers for each profile in a separate subdirectory of `data/mappers/release_#`:
+
+`exe/ccu mappers write -p all -o data/mappers/release_# -s y`
+
+For details on the options:
+
+`exe/ccu mappers help write`
+
+== Validate the newly created mappers
+
+See the description under `exe/ccu mappers help validate` for what this checks.
+
+The following will recursively validate (in all the subdirectories) all the mappers created in the previous step.
+
+`exe/ccu mappers validate -i data/mappers/release_#`
+
+== Create the mapper manifest
+
+The following will create a manifest listing all *valid* mappers created above:
+
+`exe/ccu mappers manifest -i release_# -o data/mappers/community_profile_mappers_release_#.json`

--- a/doc/managing_profiles_and_configs.adoc
+++ b/doc/managing_profiles_and_configs.adoc
@@ -1,0 +1,25 @@
+= Managing profiles and configs
+
+In the context of the Untangler:
+
+profile:: Set of fields and field configurations. Community profiles include `core`, `anthro`, etc. If any fields have been custom configured, then this will be a new custom profile. Many LYRASIS CSpace clients have their own custom profiles, since even changing the values in a static option list is a field customization.
+config:: The JSON file available from a given CSpace application instance, at a URL simliar to: https://anthro.collectionspace.org/cspace/anthro/config. The *config* is the structured expression of a given *profile*
+
+
+Untangler commands can be run on one, multiple, or all profiles.
+
+(The exception is `exe/ccu profiles compare`, which takes exactly two profiles.)
+
+To make a profile accessible by the Untangler, put the JSON config file for the profile in `data/configs`.
+
+`exe/ccu profiles all` will list the profiles currently in `data/configs`.
+
+In the Github repo, `data/configs` contains the current versions of all community profiles and `data/config_holder` stores previous versions of the community profiles.
+
+In your local copy, you can move files around however necessary to support your work.
+
+Want a spreadsheet of all fields in all profiles except `materials`? Move the `materials` config JSON out of `data/configs`.
+
+Want record mappers for all past versions of all profiles? Put all those JSON files in `data/configs`.
+
+

--- a/lib/cspace_config_untangler/version.rb
+++ b/lib/cspace_config_untangler/version.rb
@@ -1,3 +1,3 @@
 module CspaceConfigUntangler
-  VERSION = "1.8.6"
+  VERSION = "1.8.7"
 end


### PR DESCRIPTION
- adds `data/mapper_manifests` for storing mapper manifests used by [`cspace-batch-import`](https://github.com/collectionspace/cspace-batch-import)
- provides a manifest with all release 6.1 community mappers, and a dev manifest with `collectionobject` and `concept-associated` mappers for the 6.1 release versions of the `core`, `anthro`, and `fcart` profiles. 
- adds documentation on how to generate mappers and mapper manifests