### PR TITLE
Fix class options in cli/profiles commands

### DIFF
--- a/lib/cspace_config_untangler/cli/profiles.rb
+++ b/lib/cspace_config_untangler/cli/profiles.rb
@@ -8,9 +8,11 @@ module CspaceConfigUntangler
   module Cli
     class Profiles < SubcommandBase
       remove_class_option :rectypes
+      remove_class_option :profiles
 
       desc "by_extension",
         "List all extensions used in profiles, and list which profile uses each"
+      method_option(*profiles_option)
       def by_extension
         exts = {}
         get_profiles.each do |p|
@@ -30,6 +32,7 @@ module CspaceConfigUntangler
 
       desc "check",
         "Prints to screen the names of profiles that will be processed"
+      method_option(*profiles_option)
       def check
         profiles = get_profiles
         say(profiles.join("\n"))
@@ -57,6 +60,7 @@ module CspaceConfigUntangler
         > $ exe/ccu profiles compare -p core_6_1_0,anthro_4_1_2
         >   -o /Users/you/files
       LONGDESC
+      method_option(*profiles_option)
       option :output_dir,
         desc: "Path to directory in which to output file. Name of the file "\
         "is hardcoded, using the names of the profiles.",
@@ -83,6 +87,7 @@ module CspaceConfigUntangler
       desc "readable",
         "REFORMATS (in place) JSON profile configs so that they are not one "\
         "very long line. Non-destructive if run over JSON multiple times."
+      method_option(*profiles_option)
       def readable
         message = []
         get_profiles.each do |p|
@@ -94,8 +99,6 @@ module CspaceConfigUntangler
         end
         say(message.join("\n"))
       end
-
-      remove_class_option :profiles
 
       desc "all", "Print the names of all known profiles to screen"
       def all

--- a/lib/cspace_config_untangler/cli/subcommand_base.rb
+++ b/lib/cspace_config_untangler/cli/subcommand_base.rb
@@ -7,16 +7,6 @@ module CspaceConfigUntangler
     class SubcommandBase < Thor
       include CCU::Cli::Helpers
 
-      def self.banner(command, namespace = nil, subcommand = false)
-        "#{basename} #{subcommand_prefix} #{command.usage}"
-      end
-
-      def self.subcommand_prefix
-        name.gsub(%r{.*::}, "").gsub(%r{^[A-Z]}) do |match|
-          match[0].downcase
-        end.gsub(%r{[A-Z]}) { |match| "-#{match[0].downcase}" }
-      end
-
       class_option :profiles,
         desc: "Comma-separated list (NO SPACES) of non-main profiles you "\
         "want to process. If not set, will run main profile only. If `all`, "\
@@ -31,6 +21,27 @@ module CspaceConfigUntangler
         type: :array,
         default: ["all"],
         aliases: "-r"
+
+      def self.profiles_option
+        [:profiles, {
+          desc: "Comma-separated list (NO SPACES) of non-main profiles you "\
+            "want to process. If not set, will run main profile only. If "\
+            "`all`, will run all known profiles.",
+          type: :string,
+          default: CCU.main_profile,
+          aliases: "-p"
+        }]
+      end
+
+      def self.banner(command, namespace = nil, subcommand = false)
+        "#{basename} #{subcommand_prefix} #{command.usage}"
+      end
+
+      def self.subcommand_prefix
+        name.gsub(%r{.*::}, "").gsub(%r{^[A-Z]}) do |match|
+          match[0].downcase
+        end.gsub(%r{[A-Z]}) { |match| "-#{match[0].downcase}" }
+      end
     end
   end
 end


### PR DESCRIPTION
At some point, `remove_class_options` worked like the `private` or `protected` keywords, and would only remove the options from following command definitions.

No commands in the cli/profiles class had the --profiles option, though this class option was removed near the bottom of the class definition.

Perhaps this is broken in this application because of the way subcommands are set up? It doesn't seem to be due to subclassing from SubcommandBase.

At any rate, it is now fixed, though I've introduced a redundant (to the class_option definition) :profiles_option method definition in SubcommandBase to do so.