### PR TITLE
Get RecordType namespace from first advancedSearch value

### DIFF
--- a/lib/cspace_config_untangler/record_type.rb
+++ b/lib/cspace_config_untangler/record_type.rb
@@ -149,24 +149,28 @@ module CspaceConfigUntangler
     def id_field
       case @service_type
       when "object"
-        id_field = "objectNumber"
+        "objectNumber"
       when "authority"
-        id_field = "shortIdentifier"
+        "shortIdentifier"
       when "procedure"
         required_mappings = batch_mappings.select { |m| m.required == "y" }
         case required_mappings.length
         when 0
-          id_field = "potTagNumber" if @name == "pottag"
+          case name
+          when "loanout" then "loanOutNumber"
+          when "pottag" then "potTagNumber"
+          end
         when 1
-          id_field = required_mappings.first.fieldname
+          required_mappings.first.fieldname
         else
+          case name
+          when "movement" then "movementReferenceNumber"
           # osteology has 3 required fields, but only the ID is suitable for use
           # here
-          id_field = "InventoryID" if @name == "osteology"
-          id_field = "movementReferenceNumber" if @name == "movement"
+          when "osteology" then "InventoryID"
+          end
         end
       end
-      id_field
     end
 
     def search_field
@@ -368,10 +372,7 @@ module CspaceConfigUntangler
     end
 
     def get_namespace
-      return "ns2:dutiesofcare_common" if name == "dutyofcare"
-      return "ns2:propagations_common" if name == "propagation"
-
-      "ns2:#{service_config.document_name.downcase}_common"
+      config.dig("advancedSearch", "value", 0, "path")&.split("/")&.first
     end
   end
 end

--- a/spec/cspace_config_untangler/record_mapper/record_mapping_spec.rb
+++ b/spec/cspace_config_untangler/record_mapper/record_mapping_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CCU::RecordMapper::RecordMapping do
   end
   let(:profilename) { "core" }
   let(:rectypes) { ["collectionobject", "concept", "movement"] }
-  let(:release) { "6_1" }
+  let(:release) { "8_1" }
   let(:profile) { generator.profile }
 
   describe RecordMapping do


### PR DESCRIPTION
Across record types, neither documentName nor servicePath is consistently appended to "_common" to create the base namespace of a record type.

The first field in the advancedSearch screen for a record type is always the identifier field, which is always in the base namespace.