### PR TITLE
Minor changes to optlist override manifest format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ jard_errors.txt
 /data/templates_holder/private
 /data/configs/*.json
 /data/tmp/
+/data/config_holder/temp/

--- a/data/mapper_manifests/optlist_overrides.json
+++ b/data/mapper_manifests/optlist_overrides.json
@@ -1,107 +1,107 @@
 {
   "data configs": [
     {
-      "digest": "d229972dc381bb6ab337186762a321bde9ba61233b8b7021318522ae3e82b490",
+      "profile": "kennesaw",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/kennesaw.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "45293590f8f3dfb45a6c420bb4e008d7f708ff7a412df24f281a14ab032926a0",
+      "profile": "fwm",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/fwm.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "c2d4b5de664a99b365fb98fcab201e993e86f2cf9e8557b830634fc8a152b9c6",
+      "profile": "cinefiles",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/cinefiles.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "a544a7992ccf46317f38202371e0e016227b47662072229e68658d543f649624",
+      "profile": "ohiohistory",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/ohc.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "c71e64d3a0f808ebdc85f5edfc77141d66ce8c656ee1fda75b3688cf05e8210d",
+      "profile": "gsd",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/gsd.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "6bd3498f4f4a92aca2e815e3b99377cd8197d7173771b04cbe568904d51e458b",
+      "profile": "nistmuseum",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/nistmuseum.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "224410727d1f2c5b0d22078dd794af3a447c0bd234443bba7674b8bef533db6d",
+      "profile": "averylibrary",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/averylibrary.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "f5dee1afb88a81ea5fae39320ee89c6bc15bc2d1d20d964760b2df2989f2e195",
+      "profile": "breman",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/breman.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "95a727ac8694a58a0e20307298ff2722432c21c4b9b8176efdf5718777e76fc9",
+      "profile": "bampfa",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/bampfa.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "416c03e07415bd034b0e20377262094e7d2d10ace502709d8624256662b95f37",
+      "profile": "mcgill",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/mcgill.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "ac44b343c2157afe8a4a04acac7af82a9b04f46b5a27f71597afd39039eb4116",
+      "profile": "hku",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/hku.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "40b97aa20cceb3b60f84d25b61b15090d31f425bd3b3ab430f79edb24ac1bf63",
+      "profile": "msstate",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/msstate.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "756081c66f9a20df5631a6e3907803428109e9fe8092b174ae8a1f7c01da5f87",
+      "profile": "athenaeum",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/athenaeum.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "75c92a3b5bbbb04a580a696bf5c74e8d891ab095b3afc2d21753c23132bb37bd",
+      "profile": "momm",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/momm.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "4fe7be9c3264d73b164f2509f3991209450d1096470377f95b36df15325d4cda",
+      "profile": "ccp",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/ccp.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "7ab0427b663334bf0f796b904240e1bb95805379a69214881a267c9a5d311bfd",
+      "profile": "mnarb",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/mnarb.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "bc29f1fa964e2bc50d276a4045b1a08a304f657eff6f40a99aad1a659404a219",
+      "profile": "catholicu",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/catholicu.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "9c6d5ba00696a6df052bd031cc9003bc608d4d5c4b0bd021dab10a032ae8a42c",
+      "profile": "calstate.staging",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/calstatestaging.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "fc5878040c794fcc90c23abdbfaef1bb8d98c909a883882eaac13fd38aa541ff",
+      "profile": "littleshell",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/littleshell.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "4aa86943b1a009a3d501cfda6654028f93b73d1b9ed1c46dd8ddc8535584598d",
+      "profile": "bplarts",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/bplarts.json",
       "dataConfigType": "optlist overrides"
     },
     {
-      "digest": "17dccd6e9e2d618e6b84fa108532f8cb370ed7c3f7763138c7b359dd54fa79af",
+      "profile": "csuchico",
       "url": "https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/optlist_overrides/csuchico.json",
       "dataConfigType": "optlist overrides"
     }

--- a/lib/cspace_config_untangler/manifest_entry.rb
+++ b/lib/cspace_config_untangler/manifest_entry.rb
@@ -17,6 +17,8 @@ module CspaceConfigUntangler
                              data_config_json.dig("config", "dataConfigType")
 
     def digest
+      return unless data_config_type == "record type"
+
       Digest::SHA256.hexdigest(data_config_text)
     end
 
@@ -24,7 +26,14 @@ module CspaceConfigUntangler
 
     attr_reader :path
 
-    def profile = data_config_json.dig("config", "profile_basename")
+    def profile
+      case data_config_type
+      when "record type"
+        data_config_json.dig("config", "profile_basename")
+      when "optlist overrides"
+        data_config_json.dig("config", "tenant_basename")
+      end
+    end
 
     def recordtype
       case data_config_type


### PR DESCRIPTION
- Add profile (the tenant basename)
- Remove digest (not used by CollectionSpace Data Toolkit)